### PR TITLE
Graph Null Path Case

### DIFF
--- a/examples/node-js-fraud-example/index.js
+++ b/examples/node-js-fraud-example/index.js
@@ -176,9 +176,11 @@ async function populateGraph() {
 
 // Returns the D3 formatted elements of paths between two given users
 async function transactionsBetweenUsers(user1, user2) {
+    if (user1 === user2) { // edge case where user chooses 2 of the same user
+        return {nodes: [], links: []};
+    }
     const p1 = await g.V().has("User", "name", user2).id().next();
     const p2 = await g.V().has("User", "name", user1).id().next();
-
     const paths = await g
         .V(p1.value)
         .outE()
@@ -191,10 +193,8 @@ async function transactionsBetweenUsers(user1, user2) {
         .path()
         .by(t.id)
         .toList();
-
     const processedPath = await processPaths(paths)
     const {vData, eData} = processedPath
-
     return makeD3Els(vData, eData)
 }
 
@@ -227,6 +227,9 @@ export async function getFullGraph() {
 async function processPaths(paths) {
     const vertexes = new Set(),
         edges = new Set();
+    if(paths.length === 0){
+        return {vData: [], eData: []}
+    }
     paths.forEach(path => {
         let i = 0;
         for (const elem of path.objects) {

--- a/examples/node-js-fraud-example/index.js
+++ b/examples/node-js-fraud-example/index.js
@@ -9,8 +9,7 @@ import {dirname} from 'path';
 // Gremlin imports
 const {traversal} = gremlin.process.AnonymousTraversalSource;
 const {DriverRemoteConnection} = gremlin.driver;
-const __ = gremlin.process.statics;
-const {t, p, direction} = gremlin.process;
+const {t, direction} = gremlin.process;
 
 // Connection Variables
 const HOST = "localhost";
@@ -38,7 +37,7 @@ app.get("/", (req, res) => {
 
 app.get("/graph", async (req, res) => {
     try {
-        let newGraph = {}
+        let newGraph
 
         const {routeKey = 'between', user1, user2} = req.query;
         switch (routeKey) {
@@ -201,7 +200,7 @@ async function transactionsBetweenUsers(user1, user2) {
 // Returns D3 Formatted elements either outgoing or incoming transactions of user1
 async function userTransactions(user1, dir) {
     const p1 = await g.V().hasLabel("User").has("name", user1).id().next()
-    let paths = [];
+    let paths
     if (dir === "out")
         paths = await g.V(p1.value)
             .outE().otherV().outE()

--- a/examples/node-js-fraud-example/public/d3Graph.js
+++ b/examples/node-js-fraud-example/public/d3Graph.js
@@ -11,9 +11,23 @@ let height = window.innerHeight;
 let simulation;
 
 export async function drawGraph() {
-    const {nodes, links} = await getGraph();
-    svg.selectAll("*").remove();
 
+    const {nodes = [], links = []} = await getGraph();
+    svg.selectAll("*").remove();
+    console.log(nodes)
+    if (nodes.length === 0) {
+        svg
+            .append("text")
+            .attr("x", width / 2)
+            .attr("y", height / 2)
+            .attr("text-anchor", "middle")
+            .attr("font-size", "24px")
+            .attr("fill", "#666")
+            .text("No transactions found");
+
+        return;
+    }
+    console.log("not empty")
     simulation = d3.forceSimulation(nodes)
         .force("link", d3.forceLink(links).id(d => d.id).distance(120).strength(1))
         .force("charge", d3.forceManyBody().strength(-100))


### PR DESCRIPTION
Added handling for cases in transactions-between-users route where two of the same users are selected (leading to no data being found) and when two users do not have any transactions together.
Bug behavior had the full graph being displayed in both cases,
new behavior displays text message detailing no vertices were found

Also removed some unused imports and constants