### PR TITLE
Fix Compilation Error in the Java Example

### DIFF
--- a/examples/java-example/src/main/java/aerospike/com/Main.java
+++ b/examples/java-example/src/main/java/aerospike/com/Main.java
@@ -78,7 +78,7 @@ public class Main {
 
         // Add Transactions
         final Random random = new Random();
-        for (final int i = 1; i <= 50; i++) {
+        for (int i = 1; i <= 50; i++) {
             final Vertex fromAccount = g.V().hasLabel("Account").sample(1).next();
             final Vertex toAccount = g.V().hasLabel("Account").sample(1).next();
             final int amount = random.nextInt(1000) + 1; // Random amount between 1 and 1000


### PR DESCRIPTION
Fix compilation error, remove `final` keyword from a loop variable which requires reassignment.

Previously when running `mvn clean install` you would get:
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] <IdeaProjects_path>/aerospike-graph/examples/java-example/src/main/java/aerospike/com/Main.java:[81,40] cannot assign a value to final variable I
```

Removing the `final` keyword fixes the issue, and the Java example runs successfully.