### PR TITLE
Fix Python Examples

### DIFF
--- a/examples/python_example/README.md
+++ b/examples/python_example/README.md
@@ -14,5 +14,5 @@ python3 -m pip install gremlinpython async_timeout
 
 Execute the python example
 ```
-python3 ./python-example.py 
+python3 ./python_example.py 
 ```

--- a/examples/python_example/food_delivery_app/food_delivery_load.py
+++ b/examples/python_example/food_delivery_app/food_delivery_load.py
@@ -43,8 +43,8 @@ def load_graph_data(vertices_path, edges_path):
 
 def main():
     # Convert relative paths to absolute paths
-    vertices_path = "/data/python_example/swimato/vertices"
-    edges_path = "/data/python_example/swimato/edges"
+    vertices_path = "/data/python_example/food_delivery_app/vertices"
+    edges_path = "/data/python_example/food_delivery_app/edges"
 
     # Load data.
     load_graph_data(vertices_path, edges_path)


### PR DESCRIPTION
There is also a corresponding PR in the documentation repo that points to the correct link: https://github.com/citrusleaf/aerospike-websites/pull/2389 

After adding those fixes - the examples seemed to work:
1. Python Example output was:
```
Values:
['aerospike', 'unlimited']

Updated:
['aerospike', 'infinite']
```
2. Food Delivery App successfully loaded the data and I was able to see a working GUI application.